### PR TITLE
feat: product detail page

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
+    "server": "json-server db.json --port 3001",
     "build": "next build",
     "start": "next start",
     "lint": "tsc --noEmit && next lint",
     "lint:fix": "tsc --noEmit && next lint --fix",
-    "prepare": "husky"
+    "prepare": "husky",
+    "start:dev": "pnpm run server & pnpm run dev"
   },
   "prettier": {
     "plugins": [

--- a/src/api/products.ts
+++ b/src/api/products.ts
@@ -11,3 +11,13 @@ export const getProducts = async () => {
     throw new Error('데이터를 불러오는 데 실패했습니다.');
   }
 };
+
+export const getProductDetail = async (id: number) => {
+  try {
+    const response = await axios.get(`${API_URL}/products/${id}`);
+    const data = response.data;
+    return data;
+  } catch (error) {
+    throw new Error('상품 상세 정보를 불러오는 데 실패했습니다.');
+  }
+};

--- a/src/api/products.ts
+++ b/src/api/products.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL;
 
-export const getProducts = async () => {
+export const getProducts = async (): Promise<Product[]> => {
   try {
     const response = await axios.get(`${API_URL}/products`);
     const data = response.data;
@@ -12,7 +12,7 @@ export const getProducts = async () => {
   }
 };
 
-export const getProductDetail = async (id: number) => {
+export const getProductDetail = async (id: number): Promise<Product> => {
   try {
     const response = await axios.get(`${API_URL}/products/${id}`);
     const data = response.data;

--- a/src/api/products.ts
+++ b/src/api/products.ts
@@ -2,9 +2,9 @@ import axios from 'axios';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL;
 
-export const getProducts = async (): Promise<Product[]> => {
+export const getProducts = async () => {
   try {
-    const response = await axios.get(`${API_URL}/products`);
+    const response = await axios.get<Product[]>(`${API_URL}/products`);
     const data = response.data;
     return data;
   } catch (error) {
@@ -12,9 +12,9 @@ export const getProducts = async (): Promise<Product[]> => {
   }
 };
 
-export const getProductDetail = async (id: number): Promise<Product> => {
+export const getProductDetail = async (id: number) => {
   try {
-    const response = await axios.get(`${API_URL}/products/${id}`);
+    const response = await axios.get<Product>(`${API_URL}/products/${id}`);
     const data = response.data;
     return data;
   } catch (error) {

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 
 import { getProducts } from '@/api/products';
 import ErrorComponent from '@/components/ErrorComponent';
+import { formattedPrice } from '@/utils/price';
 
 const Products = () => {
   const [products, setProducts] = useState<Product[]>([]);
@@ -38,10 +39,7 @@ const Products = () => {
               />
               <div className="text-center text-lg">{product.name}</div>
               <div className="text-center text-sm text-gray-500">
-                {product.price.toLocaleString('ko-KR', {
-                  style: 'currency',
-                  currency: 'KRW',
-                })}
+                {formattedPrice(product.price)}원
               </div>
             </div>
           </Link>

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -31,7 +31,7 @@ const Products = () => {
       <div className="grid grid-cols-4 flex-col items-center justify-center gap-8 max-xl:grid-cols-3 max-lg:grid-cols-2 max-sm:grid-cols-1">
         {products?.map(product => (
           <Link href={`/product/${product.id}`} key={product.id}>
-            <div className="flex transform flex-col rounded-lg p-4 shadow-sm transition-transform hover:scale-105 hover:cursor-pointer hover:shadow-2xl">
+            <div className="flex transform cursor-pointer flex-col rounded-lg p-4 shadow-sm transition-transform hover:scale-105 hover:shadow-2xl">
               <img
                 className="h-60 w-60 bg-gray-200"
                 src={product.imageURL}

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -1,3 +1,5 @@
+import axios from 'axios';
+import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
 import { getProducts } from '@/api/products';
@@ -28,23 +30,22 @@ const Products = () => {
     <div className="h-screen w-full max-w-7xl overflow-y-scroll p-4">
       <div className="grid grid-cols-4 flex-col items-center justify-center gap-8 max-xl:grid-cols-3 max-lg:grid-cols-2 max-sm:grid-cols-1">
         {products?.map(product => (
-          <div
-            key={`${product.name}-${product.id}`}
-            className="flex transform flex-col rounded-lg p-4 shadow-sm transition-transform hover:scale-105 hover:cursor-pointer hover:shadow-2xl"
-          >
-            <img
-              className="h-60 w-60 bg-gray-200"
-              src={product.imageURL}
-              alt={product.name}
-            />
-            <div className="text-center text-lg">{product.name}</div>
-            <div className="text-center text-sm text-gray-500">
-              {product.price.toLocaleString('ko-KR', {
-                style: 'currency',
-                currency: 'KRW',
-              })}
+          <Link href={`/product/${product.id}`} key={product.id}>
+            <div className="flex transform flex-col rounded-lg p-4 shadow-sm transition-transform hover:scale-105 hover:cursor-pointer hover:shadow-2xl">
+              <img
+                className="h-60 w-60 bg-gray-200"
+                src={product.imageURL}
+                alt={product.name}
+              />
+              <div className="text-center text-lg">{product.name}</div>
+              <div className="text-center text-sm text-gray-500">
+                {product.price.toLocaleString('ko-KR', {
+                  style: 'currency',
+                  currency: 'KRW',
+                })}
+              </div>
             </div>
-          </div>
+          </Link>
         ))}
       </div>
     </div>

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,7 +1,12 @@
 import type { AppProps } from 'next/app';
 
+import Layout from '@/components/layout';
 import '@/styles/globals.css';
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <Layout>
+      <Component {...pageProps} />
+    </Layout>
+  );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,12 +1,7 @@
-import Layout from '@/components/layout';
 import Products from '@/components/Products';
 
 const Home = () => {
-  return (
-    <Layout>
-      <Products />
-    </Layout>
-  );
+  return <Products />;
 };
 
 export default Home;

--- a/src/pages/product/[id].tsx
+++ b/src/pages/product/[id].tsx
@@ -75,10 +75,10 @@ export default function ProductDetail() {
         </div>
 
         <div className="mt-6 flex gap-2">
-          <button className="flex-1 bg-black py-3 text-sm font-semibold text-white hover:bg-gray-800">
+          <button className="flex-1 bg-black py-3 text-sm font-semibold text-white hover:cursor-pointer hover:bg-gray-800">
             BUY
           </button>
-          <button className="flex-1 border border-black py-3 text-sm font-semibold hover:bg-gray-100">
+          <button className="flex-1 border border-black py-3 text-sm font-semibold hover:cursor-pointer hover:bg-gray-200">
             ADD TO CART
           </button>
         </div>

--- a/src/pages/product/[id].tsx
+++ b/src/pages/product/[id].tsx
@@ -24,7 +24,7 @@ export default function ProductDetail() {
     if (params?.id) {
       loadProductDetail(Number(params.id));
     }
-  }, [params]);
+  }, [params?.id]);
 
   if (isError) {
     return <ErrorComponent message={isError.message} />;

--- a/src/pages/product/[id].tsx
+++ b/src/pages/product/[id].tsx
@@ -36,7 +36,7 @@ export default function ProductDetail() {
         <img
           src={product.imageURL}
           alt={product.name}
-          className="w-[300px] object-cover shadow-md md:w-[400px]"
+          className="w-96 object-cover shadow-md"
         />
       </div>
 

--- a/src/pages/product/[id].tsx
+++ b/src/pages/product/[id].tsx
@@ -43,14 +43,7 @@ export default function ProductDetail() {
         <p className="text-xl font-semibold text-gray-900">
           {product.price?.toLocaleString()}원
         </p>
-        <div className="space-y-1 text-sm text-gray-500">
-          <p>주말 / 공휴일을 제외한 1 - 2일 내 수령</p>
-          <p>4만원 이상 구매시 배송비 무료</p>
-        </div>
         <div className="mt-4 space-y-3">
-          <p className="text-sm text-gray-500">
-            현재 재고량 : {product.amount || 1}
-          </p>
           <input
             type="number"
             min="1"

--- a/src/pages/product/[id].tsx
+++ b/src/pages/product/[id].tsx
@@ -1,0 +1,33 @@
+import axios from 'axios';
+import { useParams } from 'next/navigation';
+import { useState, useEffect } from 'react';
+
+export default function ProductDetail() {
+  const params = useParams();
+  const [product, setProduct] = useState<Product>({} as Product);
+
+  const fetchProductDetail = async (id: number) => {
+    try {
+      const response = await axios.get(`http://localhost:3001/products/${id}`);
+      const data = response.data;
+      setProduct(data);
+      return data;
+    } catch (error) {
+      console.error(error);
+      return;
+    }
+  };
+
+  useEffect(() => {
+    fetchProductDetail(Number(params.id));
+  }, []);
+
+  return (
+    <div>
+      <img src={product.imageURL} alt={product.name} />
+      <h1>{product.name}</h1>
+      <p>{product.description}</p>
+      <p>{product.price}</p>
+    </div>
+  );
+}

--- a/src/pages/product/[id].tsx
+++ b/src/pages/product/[id].tsx
@@ -66,7 +66,7 @@ export default function ProductDetail({
             max={product.amount || 1}
             defaultValue="1"
             className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-lime-400 focus:outline-none"
-            onChange={e => handlePriceChange(e)}
+            onChange={handlePriceChange}
           />
           <div className="flex items-center justify-between text-lg font-bold text-gray-800">
             <span>총 상품 금액</span>

--- a/src/pages/product/[id].tsx
+++ b/src/pages/product/[id].tsx
@@ -1,33 +1,88 @@
-import axios from 'axios';
 import { useParams } from 'next/navigation';
 import { useState, useEffect } from 'react';
+
+import { getProductDetail } from '@/api/products';
+import ErrorComponent from '@/components/ErrorComponent';
 
 export default function ProductDetail() {
   const params = useParams();
   const [product, setProduct] = useState<Product>({} as Product);
-
-  const fetchProductDetail = async (id: number) => {
-    try {
-      const response = await axios.get(`http://localhost:3001/products/${id}`);
-      const data = response.data;
-      setProduct(data);
-      return data;
-    } catch (error) {
-      console.error(error);
-      return;
-    }
-  };
+  const [isError, setIsError] = useState<Error | null>(null);
+  const [totalPrice, setTotalPrice] = useState<number>(0);
 
   useEffect(() => {
-    fetchProductDetail(Number(params.id));
-  }, []);
+    const loadProductDetail = async (id: number) => {
+      try {
+        const productData = await getProductDetail(id);
+        setProduct(productData);
+        setTotalPrice(productData?.price || 0);
+      } catch (error) {
+        setIsError(error as Error);
+      }
+    };
+
+    if (params?.id) {
+      loadProductDetail(Number(params.id));
+    }
+  }, [params]);
+
+  if (isError) {
+    return <ErrorComponent message={isError.message} />;
+  }
 
   return (
-    <div>
-      <img src={product.imageURL} alt={product.name} />
-      <h1>{product.name}</h1>
-      <p>{product.description}</p>
-      <p>{product.price}</p>
+    <div className="flex flex-col gap-12 p-10 md:flex-row md:items-center md:justify-center">
+      <div className="flex flex-1 items-center justify-center">
+        <img
+          src={product.imageURL}
+          alt={product.name}
+          className="w-[300px] object-cover shadow-md md:w-[400px]"
+        />
+      </div>
+
+      <div className="flex-1 space-y-4">
+        <h1 className="text-2xl font-bold text-gray-800">{product?.name}</h1>
+        <p className="text-gray-500">{product?.description}</p>
+
+        <p className="text-xl font-semibold text-gray-900">
+          {product.price?.toLocaleString()}원
+        </p>
+
+        <div className="space-y-1 text-sm text-gray-500">
+          <p>주말 / 공휴일을 제외한 1 - 2일 내 수령</p>
+          <p>4만원 이상 구매시 배송비 무료</p>
+        </div>
+
+        <div className="mt-4 space-y-3">
+          <p className="text-sm text-gray-500">
+            현재 재고량 : {product.amount || 1}
+          </p>
+          <input
+            type="number"
+            min="1"
+            max={product.amount || 1}
+            defaultValue="1"
+            className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-lime-400 focus:outline-none"
+            onChange={e => {
+              const quantity = Number(e.target.value);
+              setTotalPrice(quantity * (product.price || 0));
+            }}
+          />
+          <div className="flex items-center justify-between text-lg font-bold text-gray-800">
+            <span>총 상품 금액</span>
+            <span>{totalPrice.toLocaleString()}원</span>
+          </div>
+        </div>
+
+        <div className="mt-6 flex gap-2">
+          <button className="flex-1 bg-black py-3 text-sm font-semibold text-white hover:bg-gray-800">
+            BUY
+          </button>
+          <button className="flex-1 border border-black py-3 text-sm font-semibold hover:bg-gray-100">
+            ADD TO CART
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/pages/product/[id].tsx
+++ b/src/pages/product/[id].tsx
@@ -20,12 +20,10 @@ export default function ProductDetail() {
         setIsError(error as Error);
       }
     };
-
     if (params?.id) {
       loadProductDetail(Number(params.id));
     }
   }, [params?.id]);
-
   if (isError) {
     return <ErrorComponent message={isError.message} />;
   }
@@ -39,20 +37,16 @@ export default function ProductDetail() {
           className="w-96 object-cover shadow-md"
         />
       </div>
-
       <div className="flex-1 space-y-4">
         <h1 className="text-2xl font-bold text-gray-800">{product.name}</h1>
         <p className="text-gray-500">{product.description}</p>
-
         <p className="text-xl font-semibold text-gray-900">
           {product.price?.toLocaleString()}원
         </p>
-
         <div className="space-y-1 text-sm text-gray-500">
           <p>주말 / 공휴일을 제외한 1 - 2일 내 수령</p>
           <p>4만원 이상 구매시 배송비 무료</p>
         </div>
-
         <div className="mt-4 space-y-3">
           <p className="text-sm text-gray-500">
             현재 재고량 : {product.amount || 1}
@@ -73,7 +67,6 @@ export default function ProductDetail() {
             <span>{totalPrice.toLocaleString()}원</span>
           </div>
         </div>
-
         <div className="mt-6 flex gap-2">
           <button className="flex-1 bg-black py-3 text-sm font-semibold text-white hover:cursor-pointer hover:bg-gray-800">
             BUY

--- a/src/pages/product/[id].tsx
+++ b/src/pages/product/[id].tsx
@@ -1,9 +1,9 @@
 import { GetServerSidePropsContext } from 'next';
-import { useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 
 import { getProductDetail } from '@/api/products';
 import ErrorComponent from '@/components/ErrorComponent';
-import { formattedPrice } from '@/utils/price';
+import { formattedPrice, calculateTotalPrice } from '@/utils/price';
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const { id } = context.query;
@@ -35,6 +35,11 @@ export default function ProductDetail({
 }) {
   const [totalPrice, setTotalPrice] = useState<number>(product.price || 0);
 
+  const handlePriceChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const newTotalPrice = calculateTotalPrice(e, product.price);
+    setTotalPrice(newTotalPrice);
+  };
+
   if (error) {
     return <ErrorComponent message={error.message} />;
   }
@@ -61,10 +66,7 @@ export default function ProductDetail({
             max={product.amount || 1}
             defaultValue="1"
             className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-lime-400 focus:outline-none"
-            onChange={e => {
-              const quantity = Number(e.target.value);
-              setTotalPrice(quantity * (product.price || 0));
-            }}
+            onChange={e => handlePriceChange(e)}
           />
           <div className="flex items-center justify-between text-lg font-bold text-gray-800">
             <span>총 상품 금액</span>

--- a/src/pages/product/[id].tsx
+++ b/src/pages/product/[id].tsx
@@ -41,8 +41,8 @@ export default function ProductDetail() {
       </div>
 
       <div className="flex-1 space-y-4">
-        <h1 className="text-2xl font-bold text-gray-800">{product?.name}</h1>
-        <p className="text-gray-500">{product?.description}</p>
+        <h1 className="text-2xl font-bold text-gray-800">{product.name}</h1>
+        <p className="text-gray-500">{product.description}</p>
 
         <p className="text-xl font-semibold text-gray-900">
           {product.price?.toLocaleString()}원

--- a/src/pages/product/[id].tsx
+++ b/src/pages/product/[id].tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 
 import { getProductDetail } from '@/api/products';
 import ErrorComponent from '@/components/ErrorComponent';
+import { formattedPrice } from '@/utils/price';
 
 export default function ProductDetail() {
   const params = useParams();
@@ -41,7 +42,7 @@ export default function ProductDetail() {
         <h1 className="text-2xl font-bold text-gray-800">{product.name}</h1>
         <p className="text-gray-500">{product.description}</p>
         <p className="text-xl font-semibold text-gray-900">
-          {product.price?.toLocaleString()}원
+          {formattedPrice(product.price)}원
         </p>
         <div className="mt-4 space-y-3">
           <input
@@ -57,7 +58,7 @@ export default function ProductDetail() {
           />
           <div className="flex items-center justify-between text-lg font-bold text-gray-800">
             <span>총 상품 금액</span>
-            <span>{totalPrice.toLocaleString()}원</span>
+            <span>{formattedPrice(totalPrice)}원</span>
           </div>
         </div>
         <div className="mt-6 flex gap-2">

--- a/src/utils/price.ts
+++ b/src/utils/price.ts
@@ -1,3 +1,5 @@
+import { ChangeEvent } from 'react';
+
 export const formattedPrice = (price: number): string => {
   if (price) {
     const formattedPrice = price.toLocaleString('ko-KR', {
@@ -7,4 +9,12 @@ export const formattedPrice = (price: number): string => {
     return formattedPrice.replace('₩', '').trim();
   }
   return '0';
+};
+
+export const calculateTotalPrice = (
+  e: ChangeEvent<HTMLInputElement>,
+  price: number,
+): number => {
+  const totalPrice = Number(e.target.value) * price;
+  return totalPrice;
 };

--- a/src/utils/price.ts
+++ b/src/utils/price.ts
@@ -1,14 +1,11 @@
 import { ChangeEvent } from 'react';
 
 export const formattedPrice = (price: number): string => {
-  if (price) {
-    const formattedPrice = price.toLocaleString('ko-KR', {
-      style: 'currency',
-      currency: 'KRW',
-    });
-    return formattedPrice.replace('₩', '').trim();
-  }
-  return '0';
+  const formattedPrice = price.toLocaleString('ko-KR', {
+    style: 'currency',
+    currency: 'KRW',
+  });
+  return formattedPrice.replace('₩', '').trim();
 };
 
 export const calculateTotalPrice = (

--- a/src/utils/price.ts
+++ b/src/utils/price.ts
@@ -1,0 +1,10 @@
+export const formattedPrice = (price: number): string => {
+  if (price) {
+    const formattedPrice = price.toLocaleString('ko-KR', {
+      style: 'currency',
+      currency: 'KRW',
+    });
+    return formattedPrice.replace('₩', '').trim();
+  }
+  return '0';
+};


### PR DESCRIPTION
# 작업 내용
1. 상품을 선택하여 상세 페이지로 이동
2. 상세 페이지 반응형 디자인
3. 상세 페이지에서 상품의 재고 확인
4. 상품 수량 선택 가능

# 캡쳐 화면
## 넓은 화면
<img width="981" alt="product-detail" src="https://github.com/user-attachments/assets/cacb7896-47f7-4451-b57b-b2f0c67112e6" />

## 너비가 줄었을 때의 화면
<img width="597" alt="스크린샷 2025-04-17 오후 5 14 52" src="https://github.com/user-attachments/assets/e4a62322-09c6-4be7-9498-6a2b99a9791d" />